### PR TITLE
Enable scrutinizer builds

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -19,6 +19,14 @@ tools:
         excluded_dirs:
             - vendor
             - tests
-    external_code_coverage:
-        timeout: 600
-        runs: 3
+build:
+    environment:
+        php:
+            version: 7.2       # Common versions: 5.4, 5.5, 5.6, 7.0, 7.1, or hhvm
+    tests:
+        override:
+            -
+                command: 'vendor/bin/phpunit --coverage-clover=some-file'
+                coverage:
+                    file: 'some-file'
+                    format: 'clover'

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,21 +4,12 @@
 
 Describe your changes in detail.
 
-## Motivation and context
-
-Why is this change required? What problem does it solve?
-
-If it fixes an open issue, please link to the issue here (if you write `fixes #num`
-or `closes #num`, the issue will be automatically closed when the pull is accepted.)
-
 ## How has this been tested?
 
 Please describe in detail how you tested your changes.
 
 Include details of your testing environment, and the tests you ran to
 see how your change affects other areas of the code, etc.
-
-## Screenshots (if appropriate)
 
 ## Types of changes
 
@@ -28,16 +19,10 @@ What types of changes does your code introduce? Put an `x` in all the boxes that
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
 ## Checklist:
-
-Go over all the following points, and put an `x` in all the boxes that apply.
-
-Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).
-
+Put an `x` in all the boxes that apply:
 - [ ] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
 - [ ] My pull request addresses exactly one patch/feature.
 - [ ] I have created a branch for this patch/feature.
 - [ ] Each individual commit in the pull request is meaningful.
 - [ ] I have added tests to cover my changes.
 - [ ] If my change requires a change to the documentation, I have updated it accordingly.
-
-If you're unsure about any of these, don't hesitate to ask. We're here to help!


### PR DESCRIPTION
Add scrutinizer code analysis

## Description

Added scrutinizer code-coverage

```yaml
build:
    environment:
        php:
            version: 7.2       # Common versions: 5.4, 5.5, 5.6, 7.0, 7.1, or hhvm
    tests:
        override:
            -
                command: 'vendor/bin/phpunit --coverage-clover=some-file'
                coverage:
                    file: 'some-file'
                    format: 'clover'
```

## How has this been tested?

Please describe in detail how you tested your changes.

Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

